### PR TITLE
Multi Databases Support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Build
       run: go build -v .
     - name: Run Unit Tests
-      run: go test ./... -short
+      run: go test ./... -cover -short
     - name: Start Neo4j Docker
       run: |
         docker-compose -f .github/docker-compose.yaml up -d
@@ -60,7 +60,7 @@ jobs:
       run: |
         sleep 45
     - name: Run Integration Test
-      run: go test ./... -run Integration
+      run: go test ./... -cover -run Integration
     - name: Stop Neo4j Docker
       run: |
         docker-compose -f .github/docker-compose.yaml down --remove-orphans

--- a/integration_test.go
+++ b/integration_test.go
@@ -20,9 +20,10 @@
 package gogm
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegration(t *testing.T) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -59,7 +59,16 @@ func TestIntegration(t *testing.T) {
 	req.Nil(sess.PurgeDatabase())
 
 	req.Nil(sess.Close())
+
+	// Test Opening and Closing Session using SessionConfig
+	sessConf, err := NewSessionWithConfig(SessionConfig{
+		AccessMode: AccessModeRead,
+	})
+	req.Nil(err)
+	req.Nil(sessConf.Close())
+
 	req.Nil(driver.Close())
+
 }
 
 // runs with integration test

--- a/session.go
+++ b/session.go
@@ -22,12 +22,15 @@ package gogm
 import (
 	"errors"
 	"fmt"
+	"reflect"
+
 	dsl "github.com/mindstand/go-cypherdsl"
 	"github.com/neo4j/neo4j-go-driver/neo4j"
-	"reflect"
 )
 
 const defaultDepth = 1
+
+type SessionConfig neo4j.SessionConfig
 
 type Session struct {
 	neoSess      neo4j.Session
@@ -63,6 +66,25 @@ func NewSession(readonly bool) (*Session, error) {
 	return session, nil
 }
 
+func NewSessionWithConfig(conf SessionConfig) (*Session, error) {
+	if driver == nil {
+		return nil, errors.New("driver cannot be nil")
+	}
+
+	neoSess, err := driver.NewSession(neo4j.SessionConfig{
+		AccessMode:   conf.AccessMode,
+		Bookmarks:    conf.Bookmarks,
+		DatabaseName: conf.DatabaseName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Session{
+		neoSess:      neoSess,
+		DefaultDepth: defaultDepth,
+	}, nil
+}
 func (s *Session) Begin() error {
 	if s.neoSess == nil {
 		return errors.New("neo4j connection not initialized")

--- a/session.go
+++ b/session.go
@@ -30,6 +30,9 @@ import (
 
 const defaultDepth = 1
 
+const AccessModeRead = neo4j.AccessModeRead
+const AccessModeWrite = neo4j.AccessModeWrite
+
 type SessionConfig neo4j.SessionConfig
 
 type Session struct {
@@ -49,9 +52,9 @@ func NewSession(readonly bool) (*Session, error) {
 	var mode neo4j.AccessMode
 
 	if readonly {
-		mode = neo4j.AccessModeRead
+		mode = AccessModeRead
 	} else {
-		mode = neo4j.AccessModeWrite
+		mode = AccessModeWrite
 	}
 
 	neoSess, err := driver.Session(mode)


### PR DESCRIPTION
Added a database param used by the Session Config

Also changed `neo4j.Session` with `neo4j.NewSession` to be able to pass a configuration. Might be more scalable if we pass that same Configuration at the `gogm.NewSession` level but to keep it simple, for the first iteration, I think this is ok