### PR TITLE
Fix load issue when special edge is on depth of 1

### DIFF
--- a/container_util_test.go
+++ b/container_util_test.go
@@ -122,7 +122,7 @@ func (n neo4jContainer) GetGogmConfig() *Config {
 		IsCluster:                 false,
 		Port:                      n.Port,
 		PoolSize:                  15,
-		EnableDriverLogs:          true,
+		EnableDriverLogs:          false,
 		DefaultTransactionTimeout: 2 * time.Minute,
 	}
 }

--- a/container_util_test.go
+++ b/container_util_test.go
@@ -67,7 +67,7 @@ func setupNeo4jContainer(ctx context.Context, version neo4jContainerVersion) (*n
 			return nil, err
 		}
 
-		req.Image = "neo4j:4.3.2-enterprise"
+		req.Image = "neo4j:4.4-enterprise"
 
 		req.Env["NEO4J_dbms_default__listen__address"] = "0.0.0.0"
 

--- a/decoder.go
+++ b/decoder.go
@@ -57,10 +57,6 @@ func traverseResultRecordValues(values []interface{}) ([]neo4j.Path, []neo4j.Rel
 	return paths, strictRels, isolatedNodes
 }
 
-func ptrToBool(b bool) *bool {
-	return &b
-}
-
 //decodes raw path response from driver
 //example query `match p=(n)-[*0..5]-() return p`
 func decode(gogm *Gogm, result neo4j.Result, respObj interface{}) (err error) {

--- a/decoder.go
+++ b/decoder.go
@@ -274,20 +274,34 @@ func decode(gogm *Gogm, result neo4j.Result, respObj interface{}) (err error) {
 			}
 
 			//set edge for end
-			if reflect.Indirect(*end).FieldByName(endConfig.FieldName).Kind() == reflect.Slice {
-				reflect.Indirect(*end).FieldByName(endConfig.FieldName).Set(reflect.Append(reflect.Indirect(*end).FieldByName(endConfig.FieldName), *specialEdgeValue))
+			if start.Kind() == reflect.Ptr {
+				*start = start.Elem()
+			}
+			if end.Kind() == reflect.Ptr {
+				*end = end.Elem()
+			}
+
+			if end.FieldByName(endConfig.FieldName).Kind() == reflect.Slice {
+				end.FieldByName(endConfig.FieldName).Set(reflect.Append(end.FieldByName(endConfig.FieldName), *specialEdgeValue))
 			} else {
 				//non slice relationships are already asserted to be pointers
 				end.FieldByName(endConfig.FieldName).Set(*specialEdgeValue)
 			}
 
 			//set edge for start
-			if reflect.Indirect(*start).FieldByName(startConfig.FieldName).Kind() == reflect.Slice {
-				reflect.Indirect(*start).FieldByName(startConfig.FieldName).Set(reflect.Append(reflect.Indirect(*start).FieldByName(startConfig.FieldName), *specialEdgeValue))
+			if start.FieldByName(startConfig.FieldName).Kind() == reflect.Slice {
+				start.FieldByName(startConfig.FieldName).Set(reflect.Append(start.FieldByName(startConfig.FieldName), *specialEdgeValue))
 			} else {
 				start.FieldByName(startConfig.FieldName).Set(*specialEdgeValue)
 			}
 		} else {
+			if start.Kind() == reflect.Ptr {
+				*start = start.Elem()
+			}
+			if end.Kind() == reflect.Ptr {
+				*end = end.Elem()
+			}
+
 			if end.FieldByName(endConfig.FieldName).Kind() == reflect.Slice {
 				end.FieldByName(endConfig.FieldName).Set(reflect.Append(end.FieldByName(endConfig.FieldName), start.Addr()))
 			} else {
@@ -340,12 +354,9 @@ func decode(gogm *Gogm, result neo4j.Result, respObj interface{}) (err error) {
 		reflect.Indirect(returnValue).Set(sliceValuePtr)
 
 		return err
-	} else {
-		//handles single -- already checked to make sure p2 is at least 1
-		// reflect.Indirect(returnValue).Set(*nodeLookup[pks[0]])
-
-		return err
 	}
+
+	return err
 }
 
 // getPrimaryLabel gets the label from a reflect type

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -151,7 +151,7 @@ func TestConvertNodeToValue(t *testing.T) {
 		Labels: []string{"TestStruct"},
 	}
 
-	val, err := convertNodeToValue(gogm, bn, false, ptrToBool(false), nil)
+	val, err := convertNodeToValue(gogm, bn, false, false, ptrToBool(false), nil)
 	req.Nil(err)
 	req.NotNil(val)
 	req.EqualValues(TestStruct{
@@ -182,7 +182,7 @@ func TestConvertNodeToValue(t *testing.T) {
 		Name: "test",
 	}
 	mappedTypes.Set("TestStruct", te)
-	val, err = convertNodeToValue(gogm, bn, false, ptrToBool(false), nil)
+	val, err = convertNodeToValue(gogm, bn, false, false, ptrToBool(false), nil)
 	req.Nil(err)
 	req.NotNil(val)
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -151,7 +151,7 @@ func TestConvertNodeToValue(t *testing.T) {
 		Labels: []string{"TestStruct"},
 	}
 
-	val, err := convertNodeToValue(gogm, bn)
+	val, err := convertNodeToValue(gogm, bn, false, ptrToBool(false), nil)
 	req.Nil(err)
 	req.NotNil(val)
 	req.EqualValues(TestStruct{
@@ -182,7 +182,7 @@ func TestConvertNodeToValue(t *testing.T) {
 		Name: "test",
 	}
 	mappedTypes.Set("TestStruct", te)
-	val, err = convertNodeToValue(gogm, bn)
+	val, err = convertNodeToValue(gogm, bn, false, ptrToBool(false), nil)
 	req.Nil(err)
 	req.NotNil(val)
 }

--- a/save.go
+++ b/save.go
@@ -438,6 +438,7 @@ func generateCurRels(gogm *Gogm, parentPtr uintptr, current *reflect.Value, curr
 			for i := 0; i < slLen; i++ {
 				relVal := relField.Index(i)
 
+				fmt.Println("calling process struct many from generate cur rels")
 				newParentId, _, _, _, _, followVal, err := processStruct(gogm, conf, &relVal, curPtr)
 				if err != nil {
 					return err
@@ -471,6 +472,7 @@ func generateCurRels(gogm *Gogm, parentPtr uintptr, current *reflect.Value, curr
 				}
 			}
 		} else {
+			fmt.Println("calling processStruct many from generateCurRels")
 			newParentId, _, _, _, _, followVal, err := processStruct(gogm, conf, &relField, curPtr)
 			if err != nil {
 				return err
@@ -782,6 +784,7 @@ func parseStruct(gogm *Gogm, parentPtr uintptr, edgeLabel string, parentIsStart 
 
 			for i := 0; i < slLen; i++ {
 				relVal := relField.Index(i)
+				fmt.Printf("calling process struct many from parse struct\ntype=%v\n", current.Type().String())
 				newParentId, newEdgeLabel, newParentIsStart, newDirection, newEdgeParams, followVal, err := processStruct(gogm, conf, &relVal, curPtr)
 				if err != nil {
 					return err
@@ -793,6 +796,7 @@ func parseStruct(gogm *Gogm, parentPtr uintptr, edgeLabel string, parentIsStart 
 				}
 			}
 		} else {
+			fmt.Printf("calling process struct single from parse struct\n")
 			newParentId, newEdgeLabel, newParentIsStart, newDirection, newEdgeParams, followVal, err := processStruct(gogm, conf, &relField, curPtr)
 			if err != nil {
 				return err
@@ -835,6 +839,7 @@ func processStruct(gogm *Gogm, fieldConf decoratorConfig, relValue *reflect.Valu
 			return 0, "", false, 0, nil, nil, errors.New("edge is invalid, sides are not set")
 		}
 
+		// get actual type from interface
 		startVal := startValSlice[0].Elem()
 		endVal := endValSlice[0].Elem()
 
@@ -848,13 +853,16 @@ func processStruct(gogm *Gogm, fieldConf decoratorConfig, relValue *reflect.Valu
 			params = map[string]interface{}{}
 		}
 
-		if startVal.Pointer() == curPtr {
+		startPtr, endPtr, relPTR := startVal.Pointer(), endVal.Pointer(), relValue.Pointer()
+		fmt.Printf("startPTR=%v\nendPTR=%v\nrelPTR=%v\ncurPTR=%v\n", startPtr, endPtr, relPTR, curPtr)
+		fmt.Printf("startType=%v\nendType=%v\ncurType=%v\n", startVal.Type().String(), endVal.Type().String(), relValue.Type().String())
+		if startPtr == curPtr {
 
 			//follow the end
 			retVal := endValSlice[0].Elem()
 
 			return curPtr, edgeLabel, true, fieldConf.Direction, params, &retVal, nil
-		} else if endVal.Pointer() == curPtr {
+		} else if endPtr == curPtr {
 			///follow the start
 			retVal := startValSlice[0].Elem()
 

--- a/save.go
+++ b/save.go
@@ -438,7 +438,6 @@ func generateCurRels(gogm *Gogm, parentPtr uintptr, current *reflect.Value, curr
 			for i := 0; i < slLen; i++ {
 				relVal := relField.Index(i)
 
-				fmt.Println("calling process struct many from generate cur rels")
 				newParentId, _, _, _, _, followVal, err := processStruct(gogm, conf, &relVal, curPtr)
 				if err != nil {
 					return err
@@ -472,7 +471,6 @@ func generateCurRels(gogm *Gogm, parentPtr uintptr, current *reflect.Value, curr
 				}
 			}
 		} else {
-			fmt.Println("calling processStruct many from generateCurRels")
 			newParentId, _, _, _, _, followVal, err := processStruct(gogm, conf, &relField, curPtr)
 			if err != nil {
 				return err
@@ -784,7 +782,6 @@ func parseStruct(gogm *Gogm, parentPtr uintptr, edgeLabel string, parentIsStart 
 
 			for i := 0; i < slLen; i++ {
 				relVal := relField.Index(i)
-				fmt.Printf("calling process struct many from parse struct\ntype=%v\n", current.Type().String())
 				newParentId, newEdgeLabel, newParentIsStart, newDirection, newEdgeParams, followVal, err := processStruct(gogm, conf, &relVal, curPtr)
 				if err != nil {
 					return err
@@ -796,7 +793,6 @@ func parseStruct(gogm *Gogm, parentPtr uintptr, edgeLabel string, parentIsStart 
 				}
 			}
 		} else {
-			fmt.Printf("calling process struct single from parse struct\n")
 			newParentId, newEdgeLabel, newParentIsStart, newDirection, newEdgeParams, followVal, err := processStruct(gogm, conf, &relField, curPtr)
 			if err != nil {
 				return err
@@ -853,20 +849,11 @@ func processStruct(gogm *Gogm, fieldConf decoratorConfig, relValue *reflect.Valu
 			params = map[string]interface{}{}
 		}
 
-		startPtr, endPtr, relPTR := startVal.Pointer(), endVal.Pointer(), relValue.Pointer()
-		fmt.Printf("startPTR=%v\nendPTR=%v\nrelPTR=%v\ncurPTR=%v\n", startPtr, endPtr, relPTR, curPtr)
-		fmt.Printf("startType=%v\nendType=%v\ncurType=%v\n", startVal.Type().String(), endVal.Type().String(), relValue.Type().String())
+		startPtr, endPtr := startVal.Pointer(), endVal.Pointer()
 		if startPtr == curPtr {
-
-			//follow the end
-			retVal := endValSlice[0].Elem()
-
-			return curPtr, edgeLabel, true, fieldConf.Direction, params, &retVal, nil
+			return startPtr, edgeLabel, true, fieldConf.Direction, params, &endVal, nil
 		} else if endPtr == curPtr {
-			///follow the start
-			retVal := startValSlice[0].Elem()
-
-			return curPtr, edgeLabel, false, fieldConf.Direction, params, &retVal, nil
+			return endPtr, edgeLabel, false, fieldConf.Direction, params, &startVal, nil
 		} else {
 			return 0, "", false, 0, nil, nil, errors.New("edge is invalid, doesn't point to parent vertex")
 		}

--- a/util.go
+++ b/util.go
@@ -39,6 +39,10 @@ func int64SliceContains(s []int64, e int64) bool {
 	return false
 }
 
+func ptrToBool(b bool) *bool {
+	return &b
+}
+
 // sets uuid for stuct if uuid field is empty
 func handleNodeState(pkStrat *PrimaryKeyStrategy, val *reflect.Value) (isNew bool, id int64, relConfig map[string]*RelationConfig, err error) {
 	if val == nil {


### PR DESCRIPTION
# Committer Notes
Fixes error found at GraphConnect

Changes:
- Cleaned up decode function. Removed pointers where unnecessary
- Added check if multilevel pointer is passed into decode (no `**Node`)
- In the case that the primary node is loading special edges, set decode to use existing pointer instead of creating a new one. This solves the issue where the system can not traverse if the 1st level edge is loaded.
- Added test to replicate and prove the fix works
