### PR TITLE
pass boltLogger to driver

### DIFF
--- a/sessionv2.go
+++ b/sessionv2.go
@@ -59,6 +59,7 @@ func newSessionWithConfigV2(gogm *Gogm, conf SessionConfig) (*SessionV2Impl, err
 		Bookmarks:    conf.Bookmarks,
 		DatabaseName: conf.DatabaseName,
 		FetchSize:    neo4j.FetchDefault,
+		BoltLogger:   conf.BoltLogger,
 	})
 
 	return &SessionV2Impl{


### PR DESCRIPTION
# Committer Notes
pass BoltLogger to driver, so that we can define the driver's log output
