### PR TITLE
Fix reflect.Convert in ptr struct values

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -668,9 +668,7 @@ func convertToValue(gogm *Gogm, graphId int64, conf structDecoratorConfig, props
 			} else {
 				if indirect.FieldByName(field).Kind() == reflect.Pointer {
 					// add the catch here in case reflect.IsZero doesnt catch a nil pointer
-					if !rawVal.IsNil() {
-						indirect.FieldByName(field).Set(rawVal.Convert(reflect.PointerTo(indirect.FieldByName(field).Type())))
-					}
+					indirect.FieldByName(field).Set(rawVal.Convert(reflect.PointerTo(indirect.FieldByName(field).Type())))
 				} else {
 					// calling this on ptr value will panic as it tries to convert *T to **T, hence the guard in ln 669
 					indirect.FieldByName(field).Set(rawVal.Convert(indirect.FieldByName(field).Type()))

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -203,6 +203,7 @@ type a struct {
 	PropsTest2        []string               `gogm:"properties;name=props2"`
 	PropsTest3        []int                  `gogm:"properties;name=props3"`
 	TestField         string                 `gogm:"name=test_field"`
+	TestFieldPtr      *string                `gogm:"name=test_field_ptr"`
 	TestTypeDefString tdString               `gogm:"name=test_type_def_string"`
 	TestTypeDefInt    tdInt                  `gogm:"name=test_type_def_int"`
 	SingleA           *b                     `gogm:"direction=incoming;relationship=test_rel"`
@@ -437,6 +438,7 @@ func TestDecode2(t *testing.T) {
 
 	fTime := time.Now().UTC()
 
+	pS := "ptr value"
 	vars := [][]interface{}{
 		{
 			neo4j.Path{
@@ -444,9 +446,10 @@ func TestDecode2(t *testing.T) {
 					{
 						Labels: []string{"b"},
 						Props: map[string]interface{}{
-							"test_field": "test",
-							"uuid":       "dasdfas",
-							"test_time":  fTime,
+							"test_field":     "test",
+							"uuid":           "dasdfas",
+							"test_time":      fTime,
+							"test_field_ptr": &pS,
 						},
 						Id: 2,
 					},

--- a/decorator_test.go
+++ b/decorator_test.go
@@ -396,6 +396,7 @@ type validStruct struct {
 	embedTest
 	IndexField             string                 `gogm:"index;name=index_field"`
 	UniqueField            int                    `gogm:"unique;name=unique_field"`
+	PtrField               *string                `gogm:"name=ptr_field"`
 	OneToOne               *validStruct           `gogm:"relationship=one2one;direction=incoming"`
 	ManyToOne              []*a                   `gogm:"relationship=many2one;direction=outgoing"`
 	SpecialOne             *c                     `gogm:"relationship=specC;direction=outgoing"`
@@ -428,7 +429,7 @@ func (v *validStruct) GetLabels() []string {
 	return []string{"validStruct"}
 }
 
-//issue is that it has no id defined
+// issue is that it has no id defined
 type mostlyValidStruct struct {
 	IndexField  string `gogm:"index;name=index_field"`
 	UniqueField int    `gogm:"unique;name=unique_field"`
@@ -438,14 +439,14 @@ func (m *mostlyValidStruct) GetLabels() []string {
 	return []string{"mostlyValidStruct"}
 }
 
-//nothing defined
+// nothing defined
 type emptyStruct struct{}
 
 func (e *emptyStruct) GetLabels() []string {
 	return []string{"emptyStruct"}
 }
 
-//has a valid field but also has a messed up one
+// has a valid field but also has a messed up one
 type invalidStructDecorator struct {
 	Id   int64  `gogm:"name=id"`
 	UUID string `gogm:"pk;name=uuid"`
@@ -571,6 +572,13 @@ func TestGetStructDecoratorConfig(t *testing.T) {
 				Name:       "index_field",
 				Index:      true,
 				Type:       reflect.TypeOf(""),
+				ParentType: reflect.TypeOf(validStruct{}),
+			},
+			"PtrField": {
+				FieldName:  "PtrField",
+				Name:       "ptr_field",
+				Index:      false,
+				Type:       reflect.PointerTo(reflect.TypeOf("")),
 				ParentType: reflect.TypeOf(validStruct{}),
 			},
 			"UniqueField": {

--- a/gogm.go
+++ b/gogm.go
@@ -25,7 +25,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 
@@ -190,7 +190,7 @@ func (g *Gogm) initDriver(ctx context.Context) error {
 		// handle deprecated config support
 		if g.config.CAFileLocation != "" {
 			g.logger.Debugf("loading ca file at location `%s`", g.config.CAFileLocation)
-			bytes, err := ioutil.ReadFile(g.config.CAFileLocation)
+			bytes, err := os.ReadFile(g.config.CAFileLocation)
 			if err != nil {
 				return fmt.Errorf("failed to open ca file, %w", err)
 			}
@@ -225,7 +225,13 @@ func (g *Gogm) initDriver(ctx context.Context) error {
 
 		if isEncrypted {
 			if g.config.TLSConfig.RootCAs != nil {
-				neoConf.RootCAs = g.config.TLSConfig.RootCAs
+				if neoConf.TlsConfig != nil {
+					neoConf.TlsConfig.RootCAs = g.config.TLSConfig.RootCAs
+				} else {
+					neoConf.TlsConfig = &tls.Config{
+						RootCAs: g.config.TLSConfig.RootCAs,
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Committer Notes
- Fixes panic in decoder.go `convertToValue` which arises from reflect.Convert on pointer field against non pointer typedef
- Fixes TLS configuration method to ensure nil TLS config inherits Root CAs & TLS methods are up to date with neo4j go driver methods

## Checklist
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have included new tests that address the changes
